### PR TITLE
Add missing ARM v7 startup script

### DIFF
--- a/Dockerfile.armv7
+++ b/Dockerfile.armv7
@@ -33,67 +33,6 @@ RUN echo "🧹 Cleaning up dev dependencies..." && \
     npm cache clean --force && \
     echo "✅ Production dependencies installed"
 
-# Create production start script for ARM v7
-RUN echo '#!/bin/sh\n\
-echo "Starting iPerf3 Web Container (ARM v7)..."\n\
-\n\
-# Set defaults\n\
-export IPERF_PORT=${IPERF_PORT:-5201}\n\
-export WEB_PORT=${WEB_PORT:-8080}\n\
-export HOSTNAME=${HOSTNAME:-$(hostname)}\n\
-export DISCOVERY_INTERVAL=${DISCOVERY_INTERVAL:-30}\n\
-export HISTORY_RETENTION=${HISTORY_RETENTION:-30}\n\
-\n\
-echo "Configuration:"\n\
-echo "  Hostname: $HOSTNAME"\n\
-echo "  iPerf3 Port: $IPERF_PORT"\n\
-echo "  Web Port: $WEB_PORT"\n\
-echo "  Discovery Interval: ${DISCOVERY_INTERVAL}s"\n\
-echo "  History Retention: ${HISTORY_RETENTION} days"\n\
-\n\
-# Ensure data directory exists and has correct permissions\n\
-echo "Initializing data directory..."\n\
-mkdir -p /app/data\n\
-if [ "$(id -u)" -eq 0 ]; then\n\
-    # Running as root, fix ownership\n\
-    chown -R node:node /app/data\n\
-    chmod 755 /app/data\n\
-else\n\
-    # Running as non-root, just ensure it'\''s writable\n\
-    chmod 755 /app/data 2>/dev/null || true\n\
-fi\n\
-\n\
-# Test if we can write to the data directory\n\
-if ! touch /app/data/.write_test 2>/dev/null; then\n\
-    echo "ERROR: Cannot write to /app/data directory"\n\
-    echo "Please ensure the volume is mounted with correct permissions:"\n\
-    echo "  docker run -v /host/path:/app/data ..."\n\
-    echo "Or create the directory on the host first:"\n\
-    echo "  mkdir -p /host/path && chown 1001:1001 /host/path"\n\
-    exit 1\n\
-fi\n\
-rm -f /app/data/.write_test\n\
-\n\
-echo "Data directory initialized successfully"\n\
-\n\
-# Start iPerf3 server in background\n\
-echo "Starting iPerf3 server on port $IPERF_PORT..."\n\
-iperf3 -s -p $IPERF_PORT -D\n\
-\n\
-# Wait a moment for iPerf3 to start\n\
-sleep 2\n\
-\n\
-# Verify iPerf3 is running\n\
-if ! pgrep -f "iperf3 -s" > /dev/null; then\n\
-    echo "ERROR: Failed to start iPerf3 server"\n\
-    exit 1\n\
-fi\n\
-\n\
-echo "iPerf3 server started successfully"\n\
-\n\
-# Start the Node.js web application using compiled JavaScript\n\
-echo "Starting web application on port $WEB_PORT..."\n\
-exec node dist/src/server/index.js' > ./scripts/start-armv7.sh
 
 # Set permissions
 RUN mkdir -p /app/data && \

--- a/scripts/start-armv7.sh
+++ b/scripts/start-armv7.sh
@@ -1,0 +1,61 @@
+#!/bin/sh
+
+echo "Starting iPerf3 Web Container (ARM v7)..."
+
+# Set defaults
+export IPERF_PORT=${IPERF_PORT:-5201}
+export WEB_PORT=${WEB_PORT:-8080}
+export HOSTNAME=${HOSTNAME:-$(hostname)}
+export DISCOVERY_INTERVAL=${DISCOVERY_INTERVAL:-30}
+export HISTORY_RETENTION=${HISTORY_RETENTION:-30}
+
+echo "Configuration:"
+echo "  Hostname: $HOSTNAME"
+echo "  iPerf3 Port: $IPERF_PORT"
+echo "  Web Port: $WEB_PORT"
+echo "  Discovery Interval: ${DISCOVERY_INTERVAL}s"
+echo "  History Retention: ${HISTORY_RETENTION} days"
+
+# Ensure data directory exists and has correct permissions
+echo "Initializing data directory..."
+mkdir -p /app/data
+if [ "$(id -u)" -eq 0 ]; then
+    # Running as root, fix ownership
+    chown -R node:node /app/data
+    chmod 755 /app/data
+else
+    # Running as non-root, just ensure it's writable
+    chmod 755 /app/data 2>/dev/null || true
+fi
+
+# Test if we can write to the data directory
+if ! touch /app/data/.write_test 2>/dev/null; then
+    echo "ERROR: Cannot write to /app/data directory"
+    echo "Please ensure the volume is mounted with correct permissions:"
+    echo "  docker run -v /host/path:/app/data ..."
+    echo "Or create the directory on the host first:"
+    echo "  mkdir -p /host/path && chown 1001:1001 /host/path"
+    exit 1
+fi
+rm -f /app/data/.write_test
+
+echo "Data directory initialized successfully"
+
+# Start iPerf3 server in background
+echo "Starting iPerf3 server on port $IPERF_PORT..."
+iperf3 -s -p $IPERF_PORT -D
+
+# Wait a moment for iPerf3 to start
+sleep 2
+
+# Verify iPerf3 is running
+if ! pgrep -f "iperf3 -s" > /dev/null; then
+    echo "ERROR: Failed to start iPerf3 server"
+    exit 1
+fi
+
+echo "iPerf3 server started successfully"
+
+# Start the Node.js web application using compiled JavaScript
+echo "Starting web application on port $WEB_PORT..."
+exec node dist/src/server/index.js


### PR DESCRIPTION
## Summary
- add `start-armv7.sh` script
- copy the script directly instead of generating it in `Dockerfile.armv7`

## Testing
- `node --version` *(fails: command not found)*
- `docker --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843413cc8f88333acf1f15a3dcd110d