### PR TITLE
Use Node 14 for armv7 build

### DIFF
--- a/Dockerfile.armv7
+++ b/Dockerfile.armv7
@@ -1,6 +1,6 @@
 # Dockerfile for ARM v7 architecture
 # Uses older Node.js version and pre-compiled TypeScript
-FROM node:18-alpine
+FROM node:14-alpine
 
 RUN apk add --no-cache iperf3 iputils traceroute dumb-init
 

--- a/README.md
+++ b/README.md
@@ -54,13 +54,13 @@ This project supports multiple architectures:
 
 - **AMD64** (x86_64) - Standard Docker image using Node.js 22 with native TypeScript support
 - **ARM64** (AArch64) - Standard Docker image using Node.js 22 with native TypeScript support  
-- **ARM v7** (ARMv7l) - Special image using Node.js 18 with pre-compiled TypeScript
+- **ARM v7** (ARMv7l) - Special image using Node.js 14 with pre-compiled TypeScript
 
 ##### ARM v7 Support
 
 Due to compatibility issues between Node.js 22 and ARM v7 architecture, ARM v7 devices use a separate Docker image with the following differences:
 
-- Uses Node.js 18 (last version with reliable ARM v7 support)
+- Uses Node.js 14 (last version with reliable ARM v7 support)
 - TypeScript is pre-compiled to JavaScript during build
 - Tagged with `-armv7` suffix
 

--- a/docs/ARM_V7_GUIDE.md
+++ b/docs/ARM_V7_GUIDE.md
@@ -15,7 +15,7 @@ ARM v7 architecture (ARMv7l) presents unique challenges due to compatibility iss
 - **Dockerfile**: `Dockerfile` (standard)
 
 ### ARM v7 Images
-- **Node.js Version**: 18 (last stable version with ARM v7 support)
+- **Node.js Version**: 14 (last stable version with ARM v7 support)
 - **TypeScript**: Pre-compiled to JavaScript during build
 - **Runtime**: Execution of compiled JavaScript files
 - **Dockerfile**: `Dockerfile.armv7` (specialized)
@@ -24,7 +24,7 @@ ARM v7 architecture (ARMv7l) presents unique challenges due to compatibility iss
 
 ### ARM v7 Build Steps
 
-1. **Base Image**: `node:18-alpine`
+1. **Base Image**: `node:14-alpine`
 2. **TypeScript Compilation**: Uses `tsconfig.armv7.json` configuration
 3. **Output**: Compiled JavaScript in `dist/` directory
 4. **Runtime**: Node.js executes compiled JavaScript
@@ -99,7 +99,7 @@ The GitHub Actions workflow (`docker-image.yml`) handles ARM v7 builds separatel
 
 1. **Node.js Compatibility**
    - Symptom: Container fails to start or crashes
-   - Solution: Ensure using Node.js 18 or earlier
+   - Solution: Ensure using Node.js 14 or earlier
 
 2. **TypeScript Compilation Errors**
    - Symptom: Build fails during TypeScript compilation


### PR DESCRIPTION
## Summary
- downgrade ARMv7 Dockerfile to node:14-alpine
- update docs and README to reference Node.js 14 for ARM v7

## Testing
- `npm run test:unit`
- `npm run lint` *(fails: ESLint config not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843514674c883338ede39e3f66a05d4